### PR TITLE
Add username / password option for sending mails

### DIFF
--- a/etc/default/systemd-status-mail
+++ b/etc/default/systemd-status-mail
@@ -14,6 +14,15 @@ ADDRESS=
 # RELAYHOST specifies the mail relay used by mailx if specified
 #RELAYHOST=relay.example.com
 
+# If the RELAYHOST requires authentication set the username here
+#MAILX_AUTH_USER=
+
+# If the RELAYHOST requires authentication set the password here
+# NOTE: If you have to set this field you should take additional
+# security measures and restrict access. The file should only be
+# readable by the "systemd-status-mail" user.
+#MAILX_AUTH_PASSWORD=
+
 # MAILX_OPTIONS specifies additional options for mailx
 #MAILX_OPTIONS="-Sverbose ..."
 

--- a/src/systemd-status-mail
+++ b/src/systemd-status-mail
@@ -5,12 +5,6 @@ if [ "$#" -lt 1 -o "$#" -gt 2 ]; then
     exit 1
 fi
 
-SERVICE="$1"
-TO="root@localhost"
-if [ -n "$2" ]; then
-    TO="$2"
-fi
-
 include () {
     test -f "$1" && . "$1"
 }
@@ -19,6 +13,14 @@ include /usr/etc/default/systemd-status-mail
 include /etc/default/systemd-status-mail
 
 HOSTNAME=${HOSTNAME:-$(hostname)}
+SERVICE="$1"
+if [ -n "$2" ]; then
+    TO="$2"
+elif [ -n "$ADDRESS" ]; then
+    TO="$ADDRESS"
+else
+    TO="root@localhost"
+fi
 
 if [ -z "$FROM" ]; then
     FROM="systemd <root@$HOSTNAME>"
@@ -47,12 +49,22 @@ $(systemctl status --lines=500 --full "$SERVICE" 2>&1)
 EOF
 	;;
     mailx)
+	MAILRC=`mktemp --tmpdir systemd-status-mail-mailx-conf.XXXXXXXXXX` || exit 1
+	export MAILRC
+	echo "set sendwait" >> $MAILRC
 	if [ -n "${RELAYHOST}" ]; then
-	    RELAY="-Ssmtp=${RELAYHOST}"
+	    echo "set smtp=${RELAYHOST@Q}" >> $MAILRC
 	fi
-	mailx $MAILX_OPTIONS -Ssendwait -s "$SERVICE ($HOSTNAME)" -r "$FROM" "$RELAY" "$TO" <<EOF
+	if [ -n "${MAILX_AUTH_USER}" ]; then
+	    echo "set smtp-auth-user=${MAILX_AUTH_USER@Q}" >> $MAILRC
+	fi
+	if [ -n "${MAILX_AUTH_PASSWORD}" ]; then
+	    echo "set smtp-auth-password=${MAILX_AUTH_PASSWORD@Q}" >> $MAILRC
+	fi
+	mailx $MAILX_OPTIONS -s "$SERVICE ($HOSTNAME)" -r "$FROM" "$TO" <<EOF
 $(systemctl status --lines=500 --full "$SERVICE" 2>&1)
 EOF
+	rm $MAILRC
 	;;
     *)
 	echo "ERROR: \"$MAILER\" is not a valid entry!" >&2

--- a/systemd/systemd-status-mail@.service.in
+++ b/systemd/systemd-status-mail@.service.in
@@ -6,8 +6,6 @@ Documentation=https://wiki.archlinux.org/title/Systemd/Timers#MAILTO
 
 [Service]
 Type=oneshot
-EnvironmentFile=-/usr/etc/default/systemd-status-mail
-EnvironmentFile=-/etc/default/systemd-status-mail
-ExecStart=@libexec@/systemd-status-mail ${ADDRESS} %i
+ExecStart=@libexec@/systemd-status-mail %i
 User=systemd-status-mail
 Group=systemd-journal


### PR DESCRIPTION
Some relay hosts require a username and password to be able to send mail, so add support for it.

As the configuration is now read in systemd-status-mail anyway discard reading the configuration in the systemd service - reading it twice serves no purpose any more.