### PR TITLE
Refresh before dup

### DIFF
--- a/src/os-update.in
+++ b/src/os-update.in
@@ -31,6 +31,7 @@ LOG_TAG="os-update"
 
 # Additional variables per package manager
 ZYPPER_NONINTERACTIVE="-y --auto-agree-with-product-licenses"
+ZYPPER_NOREFRESH="--no-refresh"
 
 
 log_error()
@@ -164,7 +165,11 @@ zypper_up() {
 }
 
 zypper_dup() {
-    zypper dup ${ZYPPER_NONINTERACTIVE}
+    if ! zypper refresh; then
+        log_error "ERROR: refresh failed"
+        exit 1
+    fi
+    zypper ${ZYPPER_NOREFRESH} dup ${ZYPPER_NONINTERACTIVE}
     eval_zypper_retval $?
 }
 

--- a/src/os-update.in
+++ b/src/os-update.in
@@ -154,21 +154,27 @@ eval_zypper_retval() {
     fi
 }
 
-zypper_security() {
-    zypper patch ${ZYPPER_NONINTERACTIVE} --category security
-    eval_zypper_retval $?
-}
-
-zypper_up() {
-    zypper up ${ZYPPER_NONINTERACTIVE}
-    eval_zypper_retval $?
-}
-
-zypper_dup() {
+zypper_refresh() {
     if ! zypper refresh; then
         log_error "ERROR: refresh failed"
         exit 1
     fi
+}
+
+zypper_security() {
+    zypper_refresh
+    zypper ${ZYPPER_NOREFRESH} patch ${ZYPPER_NONINTERACTIVE} --category security
+    eval_zypper_retval $?
+}
+
+zypper_up() {
+    zypper_refresh
+    zypper ${ZYPPER_NOREFRESH} up ${ZYPPER_NONINTERACTIVE}
+    eval_zypper_retval $?
+}
+
+zypper_dup() {
+    zypper_refresh
     zypper ${ZYPPER_NOREFRESH} dup ${ZYPPER_NONINTERACTIVE}
     eval_zypper_retval $?
 }


### PR DESCRIPTION
Plain distribution-upgrade bears the risk of removing critical system
packages in case of a refresh failure (boo#1223446). The recommended
solution is to explicitly refresh prior.